### PR TITLE
Update for osg-htc

### DIFF
--- a/.github/workflows/deploy-mkdocs.yml
+++ b/.github/workflows/deploy-mkdocs.yml
@@ -11,7 +11,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Deploy MkDocs pages
-        if: startsWith(github.repository, 'opensciencegrid/')
+        if: startsWith(github.repository, 'osg-htc/')
         uses: docker://squidfunk/mkdocs-material:7.1.0
         with:
           args: >-

--- a/docs/SLA/access-point.md
+++ b/docs/SLA/access-point.md
@@ -14,7 +14,7 @@ The Access Point is a HTCondor-based service that runs a submit host, and manage
 General Service Level Agreement
 -------------------------------
 
-<https://opensciencegrid.org/operations/SLA/general/>
+<https://osg-htc.org/operations/SLA/general/>
 
 Security Considerations
 -----------------------

--- a/docs/SLA/collector.md
+++ b/docs/SLA/collector.md
@@ -14,7 +14,7 @@ HTCondor Collector that advertises information about all of the HTCondor Compute
 General Service Level Agreement
 -------------------------------
 
-<https://opensciencegrid.org/operations/SLA/general/>
+<https://osg-htc.org/operations/SLA/general/>
 
 Security Considerations
 -----------------------

--- a/docs/SLA/general.md
+++ b/docs/SLA/general.md
@@ -35,7 +35,7 @@ Once a service can not be restored within the SLA Resolution Time specified, it 
 | 2nd | OSG Operations Coordinator |
 | 3rd | OSG Technical Director and Executive Director |
 
-Any ongoing issues will be discussed at the weekly [Operations](https://opensciencegrid.org/operations/#weekly-operations-meetings) and [Production](https://opensciencegrid.org/production/#weekly-production-meetings) meetings. "High" and possibly "Elevated" level issues will in addition require more frequent meetings of the appropriate set of people to resolve the issue in a timely manner.
+Any ongoing issues will be discussed at the weekly [Operations](/#weekly-operations-meetings) and [Production](https://osg-htc.org/production/#weekly-production-meetings) meetings. "High" and possibly "Elevated" level issues will in addition require more frequent meetings of the appropriate set of people to resolve the issue in a timely manner.
 
 Service Availability and Outages
 --------------------------------

--- a/docs/SLA/gracc.md
+++ b/docs/SLA/gracc.md
@@ -14,7 +14,7 @@ GRACC is a large database of usage information for the OSG.  GRACC includes the 
 General Service Level Agreement
 -------------------------------
 
-<https://opensciencegrid.org/operations/SLA/general/>
+<https://osg-htc.org/operations/SLA/general/>
 
 Security Considerations
 -----------------------

--- a/docs/SLA/gwms-factory.md
+++ b/docs/SLA/gwms-factory.md
@@ -14,7 +14,7 @@ The GlideinWMS Factory is responsible for serving GWMS Frontend requests and sub
 General Service Level Agreement
 -------------------------------
 
-<https://opensciencegrid.org/operations/SLA/general/>
+<https://osg-htc.org/operations/SLA/general/>
 
 Security Considerations
 -----------------------

--- a/docs/SLA/gwms-frontend.md
+++ b/docs/SLA/gwms-frontend.md
@@ -14,7 +14,7 @@ The GlideinWMS Frontend is responsible for monitoring a GWMS HTCondor pool, and 
 General Service Level Agreement
 -------------------------------
 
-<https://opensciencegrid.org/operations/SLA/general/>
+<https://osg-htc.org/operations/SLA/general/>
 
 Security Considerations
 -----------------------

--- a/docs/SLA/hosted-ce.md
+++ b/docs/SLA/hosted-ce.md
@@ -14,7 +14,7 @@ The Hosted CE (Compute Entrypoint) is a door into a computing site. Sites that p
 General Service Level Agreement
 -------------------------------
 
-<https://opensciencegrid.org/operations/SLA/general/>
+<https://osg-htc.org/operations/SLA/general/>
 
 Security Considerations
 -----------------------

--- a/docs/SLA/htcss-central-manager.md
+++ b/docs/SLA/htcss-central-manager.md
@@ -14,7 +14,7 @@ The  Central Manager is the HTCondor service that represents a HTCondor pool. It
 General Service Level Agreement
 -------------------------------
 
-<https://opensciencegrid.org/operations/SLA/general/>
+<https://osg-htc.org/operations/SLA/general/>
 
 Security Considerations
 -----------------------

--- a/docs/SLA/message-broker.md
+++ b/docs/SLA/message-broker.md
@@ -16,7 +16,7 @@ The OSG uses a commercial vendor which provides their own [SLA](https://www.clou
 General Service Level Agreement
 -------------------------------
 
-<https://opensciencegrid.org/operations/SLA/general/>
+<https://osg-htc.org/operations/SLA/general/>
 
 Security Considerations
 -----------------------

--- a/docs/SLA/oasis.md
+++ b/docs/SLA/oasis.md
@@ -14,7 +14,7 @@ The OASIS service provides users with a central location for application softwar
 General Service Level Agreement
 -------------------------------
 
-<https://opensciencegrid.org/operations/SLA/general/>
+<https://osg-htc.org/operations/SLA/general/>
 
 Security Considerations
 -----------------------

--- a/docs/SLA/osdf-cache.md
+++ b/docs/SLA/osdf-cache.md
@@ -14,7 +14,7 @@ Clients contact the closest Cache to access data from the OSDF federation. This 
 General Service Level Agreement
 -------------------------------
 
-<https://opensciencegrid.org/operations/SLA/general/>
+<https://osg-htc.org/operations/SLA/general/>
 
 Security Considerations
 -----------------------

--- a/docs/SLA/osdf-core.md
+++ b/docs/SLA/osdf-core.md
@@ -14,7 +14,7 @@ The Redirector routes cache requests to be served by the respective data origin 
 General Service Level Agreement
 -------------------------------
 
-<https://opensciencegrid.org/operations/SLA/general/>
+<https://osg-htc.org/operations/SLA/general/>
 
 Security Considerations
 -----------------------

--- a/docs/SLA/osdf-origin.md
+++ b/docs/SLA/osdf-origin.md
@@ -14,7 +14,7 @@ Server that holds the data in the OSDF federation for a particular organization
 General Service Level Agreement
 -------------------------------
 
-<https://opensciencegrid.org/operations/SLA/general/>
+<https://osg-htc.org/operations/SLA/general/>
 
 Security Considerations
 -----------------------

--- a/docs/SLA/perfsonar.md
+++ b/docs/SLA/perfsonar.md
@@ -14,7 +14,7 @@ A preliminary description of the service is available [here](https://docs.google
 General Service Level Agreement
 -------------------------------
 
-<https://opensciencegrid.org/operations/SLA/general/>
+<https://osg-htc.org/operations/SLA/general/>
 
 Security Considerations
 -----------------------

--- a/docs/SLA/software-repo.md
+++ b/docs/SLA/software-repo.md
@@ -14,7 +14,7 @@ The OSG RPM Software Repository hold files necessary to update the OSG CA distri
 General Service Level Agreement
 -------------------------------
 
-<https://opensciencegrid.org/operations/SLA/general/>
+<https://osg-htc.org/operations/SLA/general/>
 
 Security Considerations
 -----------------------

--- a/docs/SLA/topology.md
+++ b/docs/SLA/topology.md
@@ -16,7 +16,7 @@ The Topology Web service is a user facing web page that exports topology data.
 General Service Level Agreement
 -------------------------------
 
-<https://opensciencegrid.org/operations/SLA/general/>
+<https://osg-htc.org/operations/SLA/general/>
 
 Security Considerations
 -----------------------

--- a/docs/SLA/web-pages.md
+++ b/docs/SLA/web-pages.md
@@ -14,7 +14,7 @@ User facing web pages that display usage statistics, and homepage for OSG Connec
 General Service Level Agreement
 -------------------------------
 
-<https://opensciencegrid.org/operations/SLA/general/>
+<https://osg-htc.org/operations/SLA/general/>
 
 Security Considerations
 -----------------------

--- a/docs/SLA/xdlogin.md
+++ b/docs/SLA/xdlogin.md
@@ -56,7 +56,7 @@ This section deals with unplanned outages. Please see [Requests for Service Enha
 
 Detailed information on contacts are viewable on the following [MyOSG URL](https://my.opensciencegrid.org/rgsummary/xml?summary_attrs_showhierarchy=on&summary_attrs_showservice=on&summary_attrs_showfqdn=on&summary_attrs_showcontact=on&gip_status_attrs_showtestresults=on&downtime_attrs_showpast=&account_type=cumulative_hours&ce_account_type=gip_vo&se_account_type=vo_transfer_volume&bdiitree_type=total_jobs&bdii_object=service&bdii_server=is-osg&start_type=7daysago&start_date=09%2F15%2F2009&end_type=now&end_date=09%2F15%2F2009&site_10047=on&rg=on&rg_336=on&gridtype=on&gridtype_1=on&active=on&active_value=1&disable_value=1), and are maintained within the
 
-Any ongoing "Normal" or "Elevated" level issues will be discussed at the weekly [Operations](https://opensciencegrid.org/operations/#weekly-operations-meetings) and [Production](https://opensciencegrid.org/production/#weekly-production-meetings)) meetings.
+Any ongoing "Normal" or "Elevated" level issues will be discussed at the weekly [Operations](/#weekly-operations-meetings) and [Production](https://osg-htc.org/production/#weekly-production-meetings)) meetings.
 
 ## Service Availability and Outages
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,6 @@
 site_name: OSG Operations
-site_url: https://www.opensciencegrid.org/operations/
-repo_url: https://github.com/opensciencegrid/operations/
+site_url: https://osg-htc.org/operations/
+repo_url: https://github.com/osg-htc/operations/
 google_analytics: ['UA-69012-29', 'opensciencegrid.github.io']
 theme: 
   name: material


### PR DESCRIPTION
Update the absolute urls to internal pages. Change pointers to opensciencegrid.org sites that have been moved. Update the build site_url and repo_url. Update the deployment.